### PR TITLE
feat: create ccbr_macs2 Docker

### DIFF
--- a/chipseq/ccbr_macs2/Dockerfile.v1
+++ b/chipseq/ccbr_macs2/Dockerfile.v1
@@ -1,0 +1,26 @@
+FROM nciccbr/ccbr_ubuntu_base_20.04:v5
+
+# build time variables
+ARG BUILD_DATE="000000"
+ENV BUILD_DATE=${BUILD_DATE}
+ARG BUILD_TAG="000000"
+ENV BUILD_TAG=${BUILD_TAG}
+ARG REPONAME="000000"
+ENV REPONAME=${REPONAME}
+
+# insert your layers go here!
+RUN pip install MACS2
+
+# apt-install
+# RUN apt-get update \
+#     && apt-get -y upgrade \
+#     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+
+# Save Dockerfile in the docker
+COPY Dockerfile /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
+RUN chmod a+r /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
+
+# cleanup
+WORKDIR /data2
+RUN apt-get clean && apt-get purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
@kopardev 

- Uses nciccbr/ccbr_ubuntu_base_20.04, which includes bedtools for #8
- Also will satisfy #7 

p.s. I'm intentionally not using keywords for those issues here, as they won't be resolved until the container is pushed to DockerHub.

p.p.s. I don't have push access to this repo so I had to fork it.