### PR TITLE
Install conda/mamba in base container

### DIFF
--- a/common/ccbr_ubuntu_base_20.04/Dockerfile.v6
+++ b/common/ccbr_ubuntu_base_20.04/Dockerfile.v6
@@ -1,0 +1,123 @@
+FROM ubuntu:20.04
+LABEL maintainer "Vishal Koparde *(kopardev on GitHub)*"
+LABEL github_handle="kopardev"
+
+# build time variables
+ARG BUILD_DATE="000000"
+ENV BUILD_DATE=${BUILD_DATE}
+ARG BUILD_TAG="000000"
+ENV BUILD_TAG=${BUILD_TAG}
+ARG REPONAME="000000"
+ENV REPONAME=${REPONAME}
+
+RUN mkdir -p /opt2 && mkdir -p /data2
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt update && apt-get -y upgrade
+# Set the locale
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+		locales build-essential cmake cpanminus && \
+	localedef -i en_US -f UTF-8 en_US.UTF-8 && \
+	cpanm FindBin Term::ReadLine
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        bcftools \
+	bedops \
+	bedtools \
+	bowtie \
+	bowtie2 \
+	bwa \
+	bzip2 \
+	curl \
+	figlet \
+	g++ \
+	gcc \
+	gfortran \
+	git \
+	imagemagick \
+	libatlas-base-dev \
+	libblas-dev \
+	libboost-dev \
+	libbz2-dev \
+	libcurl4-openssl-dev \
+	libexpat1-dev \
+	libfreetype6-dev \
+	libgd-dev \
+	libgd-perl \
+	libgs-dev \
+	libgsl-dev \
+	libgsl0-dev \
+	libhtml-template-compiled-perl \
+	libicu-dev \
+	libjudy-dev \
+	liblapack-dev \
+	liblzma-dev \
+	libmysqlclient-dev \
+	libncurses-dev \
+	libopenmpi-dev \
+	libpng-dev \
+	librtmp-dev \
+	libssl-dev \
+	libtool \
+	libxml-libxml-debugging-perl \
+	libxml-opml-simplegen-perl \
+	libxml2-dev \
+	libxslt-dev \
+	make \
+	manpages-dev \
+	openjdk-8-jdk \
+	parallel \
+	pigz \
+	python2.7 \
+	python3-pip \
+        python3-dev \
+	rsync \
+        samtools \
+	unzip \
+        vim \
+	vcftools \
+	wget \
+	zlib1g \
+	zlib1g-dev \
+	zlibc 
+
+# Install conda and give write permissions to conda folder
+RUN echo 'export PATH=/opt2/conda/bin:$PATH' > /etc/profile.d/conda.sh && \
+    wget --quiet "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" -O ~/miniforge3.sh && \
+    /bin/bash ~/miniforge3.sh -b -p /opt2/conda && \
+    rm ~/miniforge3.sh && chmod 777 -R /opt2/conda/
+
+
+#fix python
+RUN ln -s /usr/bin/python3.8 /usr/bin/python \
+	&& ln -s /usr/bin/python2.7 /usr/bin/python2
+
+RUN python3 -m pip install --upgrade pip && \
+	pip3 install numpy && \
+	pip3 install scipy && \
+	pip3 install argparse && \
+	pip3 install pandas && \
+	pip3 install pysam
+
+#install R
+RUN apt-get install -y r-base r-base-dev r-base-core
+
+# cleanup etc
+# Save Dockerfile in the docker
+COPY Dockerfile /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
+RUN chmod a+r /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
+COPY argparse.bash /opt2
+RUN chmod -R a+rx /opt2/argparse.bash
+ENV PATH="/opt2/:$PATH"
+# conda
+ENV PATH=$PATH:/opt2/conda/bin
+RUN conda config --add channels r
+RUN conda config --add channels bioconda
+RUN conda upgrade conda
+
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    apt-get autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/
+WORKDIR /data2


### PR DESCRIPTION
Created a new version of the Ubuntu 20.04 base container that installs conda/mamba via miniforge and adds it to the path.

I tested this out and used it to create a [container that installs picard from bioconda](https://github.com/kelly-sovacool/sandbox/blob/f70d93a316cb373647d7dc82153b021eb50b10e2/docker/picard/Dockerfile#L12) and it works! 

resolves https://github.com/CCBR/kelly_log/issues/12