### PR TITLE
Fix rseqc path

### DIFF
--- a/rnaseq/ccbr_rseqc_4.0.0/Dockerfile
+++ b/rnaseq/ccbr_rseqc_4.0.0/Dockerfile
@@ -1,9 +1,5 @@
 FROM nciccbr/ccbr_ubuntu_base_20.04:v6
 
-RUN apt-get install -y zlibc zlib1g zlib1g-dev
-
-RUN apt-get install -y r-base-core libboost-dev
-
 RUN pip3 install --upgrade pip && \
     pip3 install RSeQC==4.0.0 && \
     tin.py -h

--- a/rnaseq/ccbr_rseqc_4.0.0/Dockerfile
+++ b/rnaseq/ccbr_rseqc_4.0.0/Dockerfile
@@ -1,15 +1,15 @@
-FROM nciccbr/ccbr_ubuntu_base_20.04:v1.0
+FROM nciccbr/ccbr_ubuntu_base_20.04:v6
 
 RUN apt-get install -y zlibc zlib1g zlib1g-dev
 
 RUN apt-get install -y r-base-core libboost-dev
 
-RUN pip3 install --upgrade pip && pip3 install RSeQC
+RUN pip3 install --upgrade pip && \
+    pip3 install RSeQC==4.0.0 && \
+    tin.py -h
 
 COPY Dockerfile /opt2
 
 WORKDIR /data2
 
 RUN apt-get clean
-
-MAINTAINER vishal.koparde@nih.gov

--- a/rnaseq/ccbr_rseqc_4.0.0/meta.yml
+++ b/rnaseq/ccbr_rseqc_4.0.0/meta.yml
@@ -1,0 +1,4 @@
+dockerhub_namespace: nciccbr
+image_name: ccbr_rseqc_4.0.0
+version: v2
+container: "$(dockerhub_namespace)/$(image_name):$(version)"


### PR DESCRIPTION
start from newer ccbr base container which has correct paths and permissions set up

related to https://github.com/CCBR/RENEE/issues/119