### PR TITLE
fix: use new base image for multiqc docker

### DIFF
--- a/common/ccbr_multiqc_1.15/Dockerfile
+++ b/common/ccbr_multiqc_1.15/Dockerfile
@@ -1,1 +1,1 @@
-Dockerfile.v1
+Dockerfile.v2

--- a/common/ccbr_multiqc_1.15/Dockerfile.v2
+++ b/common/ccbr_multiqc_1.15/Dockerfile.v2
@@ -1,0 +1,21 @@
+FROM nciccbr/ccbr_ubuntu_base_20.04:v7
+
+# build time variables
+ARG BUILD_DATE="000000"
+ENV BUILD_DATE=${BUILD_DATE}
+ARG BUILD_TAG="000000"
+ENV BUILD_TAG=${BUILD_TAG}
+ARG REPONAME="000000"
+ENV REPONAME=${REPONAME}
+
+# insert your layers go here!
+RUN pip install multiqc==1.15
+
+# Save Dockerfile in the docker
+COPY Dockerfile /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
+RUN chmod a+r /opt2/Dockerfile_${REPONAME}.${BUILD_TAG}
+
+# cleanup
+WORKDIR /data2
+RUN apt-get clean && apt-get purge \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/common/ccbr_multiqc_1.15/meta.yml
+++ b/common/ccbr_multiqc_1.15/meta.yml
@@ -1,0 +1,4 @@
+dockerhub_namespace: nciccbr
+image_name: ccbr_multiqc_1.15
+version: v2
+container: "$(dockerhub_namespace)/$(image_name):$(version)"


### PR DESCRIPTION
which has PYTHONPATH set to empty

related issues:

- https://github.com/CCBR/XAVIER/issues/122
- https://github.com/CCBR/Dockers/issues/33
