### PR TITLE
fix: update rseqc to use base container v7

### DIFF
--- a/rnaseq/ccbr_rseqc_4.0.0/Dockerfile
+++ b/rnaseq/ccbr_rseqc_4.0.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM nciccbr/ccbr_ubuntu_base_20.04:v6
+FROM nciccbr/ccbr_ubuntu_base_20.04:v7
 
 RUN pip3 install --upgrade pip && \
     pip3 install RSeQC==4.0.0 && \

--- a/rnaseq/ccbr_rseqc_4.0.0/meta.yml
+++ b/rnaseq/ccbr_rseqc_4.0.0/meta.yml
@@ -1,4 +1,4 @@
 dockerhub_namespace: nciccbr
 image_name: ccbr_rseqc_4.0.0
-version: v2
+version: v3
 container: "$(dockerhub_namespace)/$(image_name):$(version)"


### PR DESCRIPTION
see https://github.com/CCBR/RENEE/issues/171